### PR TITLE
Quotes in title, fix examples and use warning instead of cat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: iNZightTS
 Type: Package
-Title: Time Series for iNZight
+Title: Time Series for 'iNZight'
 Version: 1.5.2
 Authors@R: c(
     person("Tom", "Elliott", role = c("aut", "cre"), email = "tom.elliott@auckland.ac.nz", comment = c(ORCID = "0000-0002-7815-6318")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
 Suggests:
     testthat,
     covr
-Description: Provides a collection of functions for working with time series data, including functions for drawing, decomposing, and forecasting. Includes capabilities to compare multiple series and fit both additive and multiplicative models. Used by 'iNZight', a graphical user interface providing easy exploration and visualisation of data for students of statistics, available in both desktop and online versions.
+Description: Provides a collection of functions for working with time series data, including functions for drawing, decomposing, and forecasting. Includes capabilities to compare multiple series and fit both additive and multiplicative models. Used by 'iNZight', a graphical user interface providing easy exploration and visualisation of data for students of statistics, available in both desktop and online versions. Holt (1957) <doi:10.1016/j.ijforecast.2003.09.015>, Winters (1960) <doi:10.1287/mnsc.6.3.324>.
 BugReports: https://github.com/iNZightVIT/iNZightTS/issues
 Contact: inzight_support@stat.auckland.ac.nz
 URL: https://www.stat.auckland.ac.nz/~wild/iNZight/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
 Suggests:
     testthat,
     covr
-Description: Provides a collection of functions for working with time series data, including functions for drawing, decomposing, and forecasting. Includes capabilities to compare multiple series and fit both additive and multiplicative models. Used by 'iNZight', a graphical user interface providing easy exploration and visualisation of data for students of statistics, available in both desktop and online versions. Holt (1957) <doi:10.1016/j.ijforecast.2003.09.015>, Winters (1960) <doi:10.1287/mnsc.6.3.324>.
+Description: Provides a collection of functions for working with time series data, including functions for drawing, decomposing, and forecasting. Includes capabilities to compare multiple series and fit both additive and multiplicative models. Used by 'iNZight', a graphical user interface providing easy exploration and visualisation of data for students of statistics, available in both desktop and online versions. Holt (1957) <doi:10.1016/j.ijforecast.2003.09.015>, Winters (1960) <doi:10.1287/mnsc.6.3.324>, Cleveland, Cleveland, & Terpenning (1990) 'STL: A Seasonal-Trend Decomposition Procedure Based on Loess'.
 BugReports: https://github.com/iNZightVIT/iNZightTS/issues
 Contact: inzight_support@stat.auckland.ac.nz
 URL: https://www.stat.auckland.ac.nz/~wild/iNZight/

--- a/NEWS.Md
+++ b/NEWS.Md
@@ -3,6 +3,7 @@
 - add appropriate subtitle to trend panel of decomposition plot
 - fix a bug preventing `iNZightTS` from accepting a valid `stats::ts` object
 - specify `stringsAsFactors = TRUE` for upcoming R 4.0.0
+- fix documentation for CRAN
 
 ## iNZightTS 1.5.1
 __Release date__: 14 November 2019

--- a/R/compareplot.R
+++ b/R/compareplot.R
@@ -346,6 +346,7 @@ compareseasons <- function(x, multiplicative = FALSE, t = 0,
 #' @param x an iNZightTS object
 #' @param ... additional arguments passed to `plot()`
 #' @export
+#' @return NULL
 compareplot <- function(x, ...) {
     warning("Depreciated: use `plot()` instead.\n")
     if (!any(grepl("^iNZightMTS$", class(x)))) {

--- a/R/compareplot.R
+++ b/R/compareplot.R
@@ -347,7 +347,7 @@ compareseasons <- function(x, multiplicative = FALSE, t = 0,
 #' @param ... additional arguments passed to `plot()`
 #' @export
 compareplot <- function(x, ...) {
-    cat("Depreciated: use `plot()` instead.\n")
+    warning("Depreciated: use `plot()` instead.\n")
     if (!any(grepl("^iNZightMTS$", class(x)))) {
           stop("x is not an iNZightMTS object")
       }

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -6,7 +6,8 @@
 #' @param model.lim limits for the time series model
 #' @param data.name the name of the data
 #' @param ... other, ignored, arguments
-#' @return an egg/gtable
+#' @return an \code{inzdecomp} object (this is the original
+#'         object with an additional \code{decompVars} component)
 #'
 #' @examples
 #' t <- iNZightTS(visitorsQ)
@@ -14,6 +15,10 @@
 #' plot(decomp.ts)
 #'
 #' @export
+#' @references
+#' R. B. Cleveland, W. S. Cleveland, J.E. McRae, and I. Terpenning (1990)
+#' STL: A Seasonal-Trend Decomposition Procedure Based on Loess.
+#' Journal of Official Statistics, 6, 3iV73.
 decompose <- function(obj, multiplicative = FALSE, t = 10, model.lim = NULL,
                       data.name = NULL, ...) {
      if (!is.null(model.lim)) {
@@ -136,6 +141,8 @@ decompose <- function(obj, multiplicative = FALSE, t = 10, model.lim = NULL,
 #' @param xlim the x axis limits
 #' @param colour vector of three colours for trend, seasonal, and residuals, respectively
 #' @param ... additional arguments (ignored)
+#' @return Invisibly returns the original decomposition object. Mainly called
+#'         to plot the decomposition.
 #'
 #' @describeIn decompose Plot a time series decomposition
 #' @export

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -335,7 +335,7 @@ plot.inzdecomp <- function(x, recompose.progress = c(0, 0),
 #'
 #' @title Plot a Time Series Decomposition
 #'
-#' @param ... args, ignored
+#' @param ... additional arguments, ignored
 #'
 #' @return The original \code{iNZightTS} object with an item \code{decompVars}
 #' appended, containing results from the decomposition.

--- a/R/forecastplot.R
+++ b/R/forecastplot.R
@@ -11,22 +11,7 @@
 #' @param x \code{iNZightTS} object
 #' @param ... args passed on
 #'
-#' @return A multiple time series of the predicted values with columns fit,
-#' lwr and upr for the predicted values and the lower and upper bounds
-#' respectively.
-#'
-#' @references C.C Holt (1957)
-#' Forecasting seasonals and trends by exponentially weighted
-#' moving averages,
-#' ONR Research Memorandum, Carnigie Institute 52.
-#'
-#' P.R Winters (1960)
-#' Forecasting sales by exponentially weighted moving averages,
-#' \emph{Management Science} \bold{6}, 324--342.
-#'
-#' @seealso \code{\link{iNZightTS}},
-#' \code{\link{HoltWinters}}
-#'
+#' @return NULL
 #'
 #' @export
 forecastplot <-

--- a/R/forecastplot.R
+++ b/R/forecastplot.R
@@ -9,7 +9,7 @@
 #' @title Forecast plot - DEPRECATED
 #'
 #' @param x \code{iNZightTS} object
-#' @param ... args passed on
+#' @param ... additional arguments passed on
 #'
 #' @return NULL
 #'

--- a/R/forecastplot.R
+++ b/R/forecastplot.R
@@ -32,7 +32,7 @@
 forecastplot <-
     function(x, ...) {
 
-    cat("Deprecated. Use plot(x, forecast = n) instead.\n")
+    warning("Deprecated. Use plot(x, forecast = n) instead.\n")
     return(plot(x, ..., forecast = 2 * x$freq))
 
 }

--- a/R/iNZightTS.R
+++ b/R/iNZightTS.R
@@ -56,6 +56,11 @@
 #' @param ... additional information passed to \code{read.csv()} and used when
 #' \code{data} is a path
 #'
+#' @return a \code{iNZightTS} object. If multiple variables are requested,
+#'         the \code{iNZightMTS} class is added to the result. The result
+#'         object contains the original data as a time series object,
+#'         as well as information on the series start, end, and frequency.
+#'
 #' @seealso \code{\link{ts}}, \code{\link{print.iNZightTS}},
 #'
 #' @examples

--- a/R/iNZightTS.R
+++ b/R/iNZightTS.R
@@ -57,22 +57,20 @@
 #' \code{data} is a path
 #'
 #' @seealso \code{\link{ts}}, \code{\link{print.iNZightTS}},
-#'          \code{\link{rawplot}}
 #'
 #' @examples
-#' \dontrun{
 #' # create from a ts object
 #' z <- iNZightTS(UKgas)
-#' rawplot(z)
+#' plot(z)
 #'
 #' # create from a data.frame
-#' x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100), var = "Return")
+#' x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100),
+#'     var = "Return")
 #'
 #' # create from a data.frame with modified time frame
-#' y <- iNZightTS(data.frame(Return = rnorm(100)), start = c(1990, 1), end =
-#' c(1993, 5), freq = 12, var = 1)
-#' rawplot(y)
-#' }
+#' y <- iNZightTS(data.frame(Return = rnorm(100)),
+#'     start = c(1990, 1), end = c(1993, 5), freq = 12, var = 1)
+#' plot(y)
 #'
 #' @export
 iNZightTS <- function(data, start = 1, end, freq = 1, var = 2,

--- a/R/iNZightTS.R
+++ b/R/iNZightTS.R
@@ -69,8 +69,11 @@
 #' plot(z)
 #'
 #' # create from a data.frame
-#' x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100),
+#' x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1900:1999),
 #'     var = "Return")
+#' # or specify a time column
+#' x <- iNZightTS(data.frame(Return = rnorm(100), Year = 1900:1999),
+#'     var = "Return", time.col = "Year")
 #'
 #' # create from a data.frame with modified time frame
 #' y <- iNZightTS(data.frame(Return = rnorm(100)),

--- a/R/multiseries.R
+++ b/R/multiseries.R
@@ -7,6 +7,6 @@
 multiseries <- function(x,...) {
     if (!any(grepl("^iNZightMTS$", class(x))))
         stop("x is not an iNZightMTS object")
-    cat("Deprecated. Use plot(x, compare = FALSE) instead.\n")
+    warning("Deprecated. Use plot(x, compare = FALSE) instead.\n")
     plot(x, ..., compare = FALSE)
 }

--- a/R/multiseries.R
+++ b/R/multiseries.R
@@ -1,4 +1,4 @@
-#' Compare multiple timeseries - DEPRECATED
+#' Compare multiple time series - DEPRECATED
 #'
 #' @param x iNZightMTS object containing data
 #' @param ... Further arguments to be passed to `plot()`

--- a/R/multiseries.R
+++ b/R/multiseries.R
@@ -2,6 +2,7 @@
 #'
 #' @param x iNZightMTS object containing data
 #' @param ... Further arguments to be passed to `plot()`
+#' @return NULL
 #'
 #' @export
 multiseries <- function(x,...) {

--- a/R/print.iNZightTS.R
+++ b/R/print.iNZightTS.R
@@ -7,10 +7,9 @@
 #' @title Print an iNZightTS object
 #'
 #' @param x the \code{iNZightTS} object to be printed
-#'
 #' @param full whether to print all the underlying data
-#'
 #' @param ... Unused arguments. Only here for consistency with the base S3 method.
+#' @return NULL
 #'
 #' @seealso \code{\link{print}}, \code{\link{iNZightTS}}
 #'

--- a/R/print.iNZightTS.R
+++ b/R/print.iNZightTS.R
@@ -15,9 +15,7 @@
 #' @seealso \code{\link{print}}, \code{\link{iNZightTS}}
 #'
 #' @examples
-#' \dontrun{
-#' print(iNZightTS(UKgas))
-#' }
+#' iNZightTS(UKgas)
 #'
 #' @export
 print.iNZightTS <- function(x, full = FALSE, ...) {

--- a/R/rawplot.R
+++ b/R/rawplot.R
@@ -329,7 +329,7 @@ plot.iNZightTS <- function(x, multiplicative = FALSE, ylab = obj$currVar, xlab =
 #' @param ... arguments passed to `plot` method
 #' @export
 rawplot <- function(...) {
-    cat("Depreciated: use `plot()` instead.\n")
+    warning("Depreciated: use `plot()` instead.\n")
     plot(...)
 }
 

--- a/R/rawplot.R
+++ b/R/rawplot.R
@@ -23,6 +23,8 @@
 #' @param model.lim limits of the series to use for modelling/forecast
 #' @param forecast numeric, how many observations ahead to forecast (default is 0, no forecast)
 #' @param ... additional arguments (not used)
+#' @return a time series plot (constructed with ggplot2) is returned invisibly,
+#'         which can be added to if desired.
 #'
 #' @keywords timeseries
 #'

--- a/R/recompose.R
+++ b/R/recompose.R
@@ -1,7 +1,7 @@
 #' Recompose a time series object, with optional animation.
 #'
 #' @title Recompose a decomposed time series
-#' @param ... args, ignored
+#' @param ... additional arguments, ignored
 #' @return the recomposed series
 #' @author iNZight
 #' @export

--- a/R/seasonplot.R
+++ b/R/seasonplot.R
@@ -8,8 +8,8 @@
 #' @title Plot Seasonal Subseries from a Time Series
 #'
 #' @param obj an \code{iNZightTS} object
-#'
 #' @param ... Further arguments to be passed onto specific methods.
+#' @return NULL
 #'
 #' @seealso \code{\link{iNZightTS}}
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,12 @@
+## Resubmission
+This is a resubmission. In this version I have:
+* added references to the description (the STL paper has no doi or other URL)
+* added quotes around package name in title
+* removed \dontrun{} from examples (and added some more)
+* added \value to documented functions
+* replaced instances of cat() with warning() so they may be suppressed
+* this package has no additional system dependencies
+
 ## Test environments
 * local ubuntu 18.04, R 3.6.3
 * ubuntu 18.04 (on travis-ci) R oldrel, release, and devel

--- a/man/decompose.Rd
+++ b/man/decompose.Rd
@@ -59,7 +59,11 @@ how many observations have been recomposed so far}
 \item{colour}{vector of three colours for trend, seasonal, and residuals, respectively}
 }
 \value{
-an egg/gtable
+an \code{inzdecomp} object (this is the original
+        object with an additional \code{decompVars} component)
+
+Invisibly returns the original decomposition object. Mainly called
+        to plot the decomposition.
 }
 \description{
 Decompose a time series object
@@ -74,4 +78,9 @@ t <- iNZightTS(visitorsQ)
 decomp.ts <- decompose(t, data.name = "Visitors")
 plot(decomp.ts)
 
+}
+\references{
+R. B. Cleveland, W. S. Cleveland, J.E. McRae, and I. Terpenning (1990)
+STL: A Seasonal-Trend Decomposition Procedure Based on Loess.
+Journal of Official Statistics, 6, 3iV73.
 }

--- a/man/decompositionplot.Rd
+++ b/man/decompositionplot.Rd
@@ -7,7 +7,7 @@
 decompositionplot(...)
 }
 \arguments{
-\item{...}{args, ignored}
+\item{...}{additional arguments, ignored}
 }
 \value{
 The original \code{iNZightTS} object with an item \code{decompVars}

--- a/man/forecastplot.Rd
+++ b/man/forecastplot.Rd
@@ -9,7 +9,7 @@ forecastplot(x, ...)
 \arguments{
 \item{x}{\code{iNZightTS} object}
 
-\item{...}{args passed on}
+\item{...}{additional arguments passed on}
 }
 \description{
 Plot a raw time series together with it's fitted curve and add

--- a/man/forecastplot.Rd
+++ b/man/forecastplot.Rd
@@ -11,11 +11,6 @@ forecastplot(x, ...)
 
 \item{...}{args passed on}
 }
-\value{
-A multiple time series of the predicted values with columns fit,
-lwr and upr for the predicted values and the lower and upper bounds
-respectively.
-}
 \description{
 Plot a raw time series together with it's fitted curve and add
 forecasts and prediction intervals to the end.
@@ -25,18 +20,4 @@ The predictions and prediction intervals are the result of models
 fitted by the Holt-Winters method. The amount of predicted
 observations is calculated by 2 * \code{freq}, where \code{freq} is
 the frequency of the time series object.
-}
-\references{
-C.C Holt (1957)
-Forecasting seasonals and trends by exponentially weighted
-moving averages,
-ONR Research Memorandum, Carnigie Institute 52.
-
-P.R Winters (1960)
-Forecasting sales by exponentially weighted moving averages,
-\emph{Management Science} \bold{6}, 324--342.
-}
-\seealso{
-\code{\link{iNZightTS}},
-\code{\link{HoltWinters}}
 }

--- a/man/iNZightTS.Rd
+++ b/man/iNZightTS.Rd
@@ -85,8 +85,11 @@ z <- iNZightTS(UKgas)
 plot(z)
 
 # create from a data.frame
-x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100),
+x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1900:1999),
     var = "Return")
+# or specify a time column
+x <- iNZightTS(data.frame(Return = rnorm(100), Year = 1900:1999),
+    var = "Return", time.col = "Year")
 
 # create from a data.frame with modified time frame
 y <- iNZightTS(data.frame(Return = rnorm(100)),

--- a/man/iNZightTS.Rd
+++ b/man/iNZightTS.Rd
@@ -40,6 +40,12 @@ from \code{data} in the actual time series}
 
 \item{ignore.case}{logical, ignore the case?}
 }
+\value{
+a \code{iNZightTS} object. If multiple variables are requested,
+        the \code{iNZightMTS} class is added to the result. The result
+        object contains the original data as a time series object,
+        as well as information on the series start, end, and frequency.
+}
 \description{
 The function \code{iNZightTS} is used to create time-series objects used
 in iNZight.
@@ -74,22 +80,20 @@ column. If \code{end} is omitted, all of the data will be used for the
 time-series.
 }
 \examples{
-\dontrun{
 # create from a ts object
 z <- iNZightTS(UKgas)
-rawplot(z)
+plot(z)
 
 # create from a data.frame
-x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100), var = "Return")
+x <- iNZightTS(data.frame(Return = rnorm(100), Time = 1:100),
+    var = "Return")
 
 # create from a data.frame with modified time frame
-y <- iNZightTS(data.frame(Return = rnorm(100)), start = c(1990, 1), end =
-c(1993, 5), freq = 12, var = 1)
-rawplot(y)
-}
+y <- iNZightTS(data.frame(Return = rnorm(100)),
+    start = c(1990, 1), end = c(1993, 5), freq = 12, var = 1)
+plot(y)
 
 }
 \seealso{
 \code{\link{ts}}, \code{\link{print.iNZightTS}},
-         \code{\link{rawplot}}
 }

--- a/man/multiseries.Rd
+++ b/man/multiseries.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/multiseries.R
 \name{multiseries}
 \alias{multiseries}
-\title{Compare multiple timeseries - DEPRECATED}
+\title{Compare multiple time series - DEPRECATED}
 \usage{
 multiseries(x, ...)
 }
@@ -12,5 +12,5 @@ multiseries(x, ...)
 \item{...}{Further arguments to be passed to `plot()`}
 }
 \description{
-Compare multiple timeseries - DEPRECATED
+Compare multiple time series - DEPRECATED
 }

--- a/man/plot.iNZightTS.Rd
+++ b/man/plot.iNZightTS.Rd
@@ -55,6 +55,10 @@ it will be about ASPECT times wider than it is high}
 
 \item{...}{additional arguments (not used)}
 }
+\value{
+a time series plot (constructed with ggplot2) is returned invisibly,
+        which can be added to if desired.
+}
 \description{
 Draws a plot of a given \code{iNZightTS} object with the trend superimposed.
 }

--- a/man/print.iNZightTS.Rd
+++ b/man/print.iNZightTS.Rd
@@ -22,9 +22,7 @@ which the \code{iNZightTS} object has been created. The default is set
 to \code{FALSE} and only the \code{head()} of the data will be printed.
 }
 \examples{
-\dontrun{
-print(iNZightTS(UKgas))
-}
+iNZightTS(UKgas)
 
 }
 \seealso{

--- a/man/recompose.Rd
+++ b/man/recompose.Rd
@@ -7,7 +7,7 @@
 recompose(...)
 }
 \arguments{
-\item{...}{args, ignored}
+\item{...}{additional arguments, ignored}
 }
 \value{
 the recomposed series


### PR DESCRIPTION
- [x] add references to Description
- [x] remove `\dontrun` from examples, and add more
- [x] add return values to all exported functions
- [x] use message/warning instead of cat