### PR TITLE
Prevent difftime ratio

### DIFF
--- a/R/rawplot.R
+++ b/R/rawplot.R
@@ -294,7 +294,7 @@ plot_inzightts_var <- function(x, var, xlab, ylab, title, aspect, emph, pal,
     if (!is.null(aspect)) {
         y_var <- dplyr::last(as.character(var))
         p <- p + coord_fixed(
-            ratio = diff(range(lubridate::as_date(x[[xlab]]), na.rm = TRUE)) /
+            ratio = as.numeric(diff(range(lubridate::as_date(x[[xlab]]), na.rm = TRUE))) /
                 diff(range(x[[y_var]], na.rm = TRUE)) / aspect
         )
     }


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was that a difftime variable was provided to `coord_fixed(ratio)`, which now more strictly requires numeric input.
This PR casts the difftime portion to a numeric.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
