### PR TITLE
Switch to simpler if/else

### DIFF
--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -172,7 +172,11 @@ use_decomp_method <- function(method) {
         fabletools::components() |>
         dplyr::mutate(dplyr::across(
             !!var | trend | remainder | dplyr::contains("season"), function(x) {
-                dplyr::case_when(mult_fit ~ exp(x), TRUE ~ as.numeric(x))
+                if (mult_fit) {
+                    exp(x)
+                } else {
+                    as.numeric(x)
+                }
             }
         ))
 }


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

`case_when()` now warns when it looks like you are using it in place of a simpler if/else or switch statement. It is not intended to be used in this way.

I have fixed one of the places to give you an idea of what needs to change, but it looks like you do this in many places. You can check against dev dplyr with `pak::pak("tidyverse/dplyr")` to install the dev version.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!