### PR TITLE
Switch to ggtime for temporal graphics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Imports:
     lubridate,
     stringr,
     tibble,
-    urca
+    urca,
+    ggtime (>= 0.2.0)
 Suggests:
     covr,
     testthat

--- a/R/forecastplot.R
+++ b/R/forecastplot.R
@@ -374,7 +374,7 @@ plot_forecast_var <- function(x, var, xlab, ylab, title) {
     p <- x |>
         dplyr::select(-.var) |>
         dplyr::filter(.model != "Raw data") |>
-        fabletools::autoplot(.mean, linetype = ifelse(n_keys > 3, "dashed", "solid"))
+        ggtime::autoplot(.mean, linetype = ifelse(n_keys > 3, "dashed", "solid"))
     if (n_keys > 3) {
         p$mapping$group <- p$mapping$colour
         p$mapping$colour <- NULL

--- a/R/rawplot.R
+++ b/R/rawplot.R
@@ -272,7 +272,7 @@ plot_inzightts_var <- function(x, var, xlab, ylab, title, aspect, emph, pal,
         )
         x[[var]] <- x_decomp$season_adjust
     }
-    p <- fabletools::autoplot(x, !!var, linewidth = 1, alpha = op) +
+    p <- ggtime::autoplot(x, !!var, linewidth = 1, alpha = op) +
         ggplot2::labs(y = ylab, title = title) +
         ggplot2::theme(
             legend.position = if (compare) "bottom" else "none",


### PR DESCRIPTION
The recent CRAN release of fabletools v0.6.0 deprecated the ggplot2 plot helpers as part of a migration to ggtime. This PR adds ggtime as an import of the package, and replaces the use of fabletools plot functions with ggtime (>= 0.2.0).
 
A CRAN submission with these changes is appreciated, as it will help to resolve a reverse dependency check issue needed to complete the migration of these graphics functions.